### PR TITLE
Add troubleshooting docs from GitHub issues triage

### DIFF
--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -94,6 +94,13 @@ Create your user account by entering a username and password that you will remem
 - Choose 'XMLTV' and paste the URL
 - EPG data will be automatically mapped.
 
+!!! tip "EPG not showing in Jellyfin?"
+    Jellyfin is particular about channel ID formats. If your guide data isn't appearing:
+
+    1. Try adding `?tvg_id_source=tvg_id` to your EPG URL
+    2. Ensure your channels have proper TVG-IDs set (not just channel numbers)
+    3. See [Troubleshooting: Jellyfin EPG](/Dispatcharr-Docs/troubleshooting/#jellyfin-epg-not-importing-or-shows-no-guide-data) for more details.
+
 ---
 
 #### Plex

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -101,6 +101,8 @@ Create your user account by entering a username and password that you will remem
     2. Ensure your channels have proper TVG-IDs set (not just channel numbers)
     3. See [Troubleshooting: Jellyfin EPG](/Dispatcharr-Docs/troubleshooting/#jellyfin-epg-not-importing-or-shows-no-guide-data) for more details.
 
+    *Related: [#583](https://github.com/Dispatcharr/Dispatcharr/issues/583)*
+
 ---
 
 #### Plex

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -134,6 +134,9 @@ Create your user account by entering a username and password that you will remem
 !!! warning "Plex does not support VOD"
     Plex does not support Video on Demand content from Dispatcharr. If you need VOD, use Jellyfin or an Xtream Codes-compatible app instead. ([#470](https://github.com/Dispatcharr/Dispatcharr/issues/470))
 
+!!! warning "Plex only supports one EPG source"
+    Plex can only use one EPG source—either the built-in zipcode-based OTA guide OR an XMLTV file, not both simultaneously. If you have both HDHomeRun OTA channels and IPTV channels, you'll need to provide all EPG data via Dispatcharr's XMLTV output. ([#633](https://github.com/Dispatcharr/Dispatcharr/issues/633))
+
 ---
 
 #### ChannelsDVR

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -129,8 +129,11 @@ Create your user account by entering a username and password that you will remem
     ![Map EPG Plex](assets/map_epg_plex.png){style="height:70vmin"}
 - Press `Continue` and plex will now load in the channels and EPG data
 !!! note "Missing logos?"
-    Add `?cachedlogos=false` to the end of your EPG to bypass logo caching which Plex does not currently support. 
-	
+    Add `?cachedlogos=false` to the end of your EPG to bypass logo caching which Plex does not currently support.
+
+!!! warning "Plex does not support VOD"
+    Plex does not support Video on Demand content from Dispatcharr. If you need VOD, use Jellyfin or an Xtream Codes-compatible app instead. ([#470](https://github.com/Dispatcharr/Dispatcharr/issues/470))
+
 ---
 
 #### ChannelsDVR

--- a/docs/en/getting-started.md
+++ b/docs/en/getting-started.md
@@ -137,6 +137,9 @@ Create your user account by entering a username and password that you will remem
 !!! warning "Plex only supports one EPG source"
     Plex can only use one EPG source—either the built-in zipcode-based OTA guide OR an XMLTV file, not both simultaneously. If you have both HDHomeRun OTA channels and IPTV channels, you'll need to provide all EPG data via Dispatcharr's XMLTV output. ([#633](https://github.com/Dispatcharr/Dispatcharr/issues/633))
 
+!!! warning "Using Tunarr with Dispatcharr?"
+    If you use Tunarr alongside Dispatcharr, you must disable "Auto-Update Guide" and "Auto-Update Channels" in Tunarr's Plex source settings. Otherwise, Plex will periodically lose channel matching. ([#344](https://github.com/Dispatcharr/Dispatcharr/issues/344))
+
 ---
 
 #### ChannelsDVR

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -129,6 +129,8 @@ Jellyfin requires the EPG channel ID to match a specific format. If your EPG dat
 !!! tip
     If channels have no tvg-id set, Dispatcharr will use the channel number by default. Ensure your channels have proper TVG-IDs assigned for best Jellyfin compatibility.
 
+*Related: [#583](https://github.com/Dispatcharr/Dispatcharr/issues/583)*
+
 ---
 
 ## Adding multiple Dispatcharr instances to Plex

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -152,6 +152,8 @@ Plex identifies tuners by their device ID. If you're running multiple Dispatchar
 
 See [Channel Profiles](/Dispatcharr-Docs/user-guide/#channels) for more details on setting up profiles.
 
+*Related: [#734](https://github.com/Dispatcharr/Dispatcharr/issues/734)*
+
 ---
 
 ## Xtream Codes apps not working through reverse proxy

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -114,6 +114,23 @@ Additionally, if multiple network interfaces are available, you should add `?loc
     
 ---
 
+## Jellyfin EPG not importing or shows "No guide data"
+
+Jellyfin requires the EPG channel ID to match a specific format. If your EPG data isn't appearing:
+
+1. **Check the TVG-ID format**: Jellyfin prefers descriptive channel IDs like `BBC1.uk` rather than numeric IDs like `1`
+2. In Dispatcharr, go to Channels and set the **TVG-ID Source** to use TVG-ID instead of channel number
+3. Alternatively, add `?tvg_id_source=tvg_id` to your EPG URL:
+    ```
+    http://your-dispatcharr:9191/output/epg?tvg_id_source=tvg_id
+    ```
+4. Refresh your guide data in Jellyfin after making changes
+
+!!! tip
+    If channels have no tvg-id set, Dispatcharr will use the channel number by default. Ensure your channels have proper TVG-IDs assigned for best Jellyfin compatibility.
+
+---
+
 ## How do I remove all VOD from dispatcharr?
 1. In the [M3U & EPG manager](/Dispatcharr-Docs/user-guide/#m3u-epg-manager) page, click the <i data-lucide="square-pen" style="color: gold; width: 18px;"></i> edit icon for any account that provides VOD (only XC account types can provide it)
 2. Toggle `Enable VOD Scanning` on

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -131,6 +131,27 @@ Jellyfin requires the EPG channel ID to match a specific format. If your EPG dat
 
 ---
 
+## Adding multiple Dispatcharr instances to Plex
+
+Plex identifies tuners by their device ID. If you're running multiple Dispatcharr instances (e.g., one with VPN, one without), Plex may have trouble distinguishing them or hang during tuner setup.
+
+**Recommended Solution**: Use Channel Profiles instead of multiple Dispatcharr instances
+
+1. In Dispatcharr, go to the Channels page
+2. Create a new Channel Profile for each "virtual tuner" you need
+3. Add each Channel Profile to Plex as a separate HDHR device
+4. Each profile generates its own unique HDHR, M3U, and EPG URLs
+
+**Alternative workaround**: If you must use multiple instances:
+
+1. Use the M3U output from one instance as an M3U source in the other
+2. Add only one instance directly to Plex via HDHR
+3. The consolidated instance will contain channels from both
+
+See [Channel Profiles](/Dispatcharr-Docs/user-guide/#channels) for more details on setting up profiles.
+
+---
+
 ## How do I remove all VOD from dispatcharr?
 1. In the [M3U & EPG manager](/Dispatcharr-Docs/user-guide/#m3u-epg-manager) page, click the <i data-lucide="square-pen" style="color: gold; width: 18px;"></i> edit icon for any account that provides VOD (only XC account types can provide it)
 2. Toggle `Enable VOD Scanning` on

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -187,6 +187,8 @@ Make sure you also have the standard proxy location blocks for `/`, `/api/`, `/p
 !!! note
     The example nginx config in the [Reverse Proxies](/Dispatcharr-Docs/user-guide/#reverse-proxies) section should work for most setups. If you've customized it, ensure all required endpoints are being proxied.
 
+*Related: [#839](https://github.com/Dispatcharr/Dispatcharr/issues/839)*
+
 ---
 
 ## How do I remove all VOD from dispatcharr?

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -131,6 +131,9 @@ Jellyfin requires the EPG channel ID to match a specific format. If your EPG dat
 
 *Related: [#583](https://github.com/Dispatcharr/Dispatcharr/issues/583)*
 
+!!! note "Jellyfin categories"
+    Jellyfin categories (Sports, News, Movies, etc.) are passed through automatically if your source EPG includes them—no special configuration is needed in Dispatcharr. ([#538](https://github.com/Dispatcharr/Dispatcharr/issues/538))
+
 ---
 
 ## Adding multiple Dispatcharr instances to Plex

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -194,6 +194,26 @@ Make sure you also have the standard proxy location blocks for `/`, `/api/`, `/p
 
 ---
 
+## EPG shows wrong data or is "off-by-one"
+
+If your EPG data appears correct in Dispatcharr but shows the wrong programs in your client (e.g., displaying data from a different channel), this is usually caused by **overlapping channel numbers**.
+
+**Cause**: When using Auto Channel Sync, the default starting channel number is 1 for all groups. If multiple groups start at 1, channels will have duplicate numbers, confusing clients when matching EPG data.
+
+**Solution**:
+
+1. Go to M3U & EPG Manager
+2. Edit your M3U account and click "Groups"
+3. For each group using Auto Channel Sync, set a unique **Start Channel #** (e.g., Group A starts at 1, Group B at 100, Group C at 200)
+4. Save and refresh
+
+!!! tip
+    Plan your channel number ranges ahead of time to avoid overlaps. For example, allocate 1-99 for local channels, 100-199 for sports, 200-299 for movies, etc.
+
+*Related: [#563](https://github.com/Dispatcharr/Dispatcharr/issues/563)*
+
+---
+
 ## How do I remove all VOD from dispatcharr?
 1. In the [M3U & EPG manager](/Dispatcharr-Docs/user-guide/#m3u-epg-manager) page, click the <i data-lucide="square-pen" style="color: gold; width: 18px;"></i> edit icon for any account that provides VOD (only XC account types can provide it)
 2. Toggle `Enable VOD Scanning` on

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -152,6 +152,39 @@ See [Channel Profiles](/Dispatcharr-Docs/user-guide/#channels) for more details 
 
 ---
 
+## Xtream Codes apps not working through reverse proxy
+
+Some IPTV apps using Xtream Codes API (like IPTV Smarters, TiviMate) may fail when accessing Dispatcharr through a reverse proxy, especially from outside your network.
+
+**Symptoms**:
+
+* App works on local network but fails remotely
+* Login works but channels don't play
+* Streams timeout or show connection errors
+
+**Cause**: These apps construct URLs using `/live/username/password/` paths that your reverse proxy may not be forwarding.
+
+**Solution**: Update your nginx configuration to include the `/live/` endpoint:
+
+```nginx
+location /live/ {
+    proxy_pass http://dispatcharr:9191/live/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Port $server_port;
+}
+```
+
+Make sure you also have the standard proxy location blocks for `/`, `/api/`, `/proxy/`, etc.
+
+!!! note
+    The example nginx config in the [Reverse Proxies](/Dispatcharr-Docs/user-guide/#reverse-proxies) section should work for most setups. If you've customized it, ensure all required endpoints are being proxied.
+
+---
+
 ## How do I remove all VOD from dispatcharr?
 1. In the [M3U & EPG manager](/Dispatcharr-Docs/user-guide/#m3u-epg-manager) page, click the <i data-lucide="square-pen" style="color: gold; width: 18px;"></i> edit icon for any account that provides VOD (only XC account types can provide it)
 2. Toggle `Enable VOD Scanning` on

--- a/docs/en/user-guide.md
+++ b/docs/en/user-guide.md
@@ -166,6 +166,8 @@ From this page you can add and maintain your M3U accounts and EPGs
 
             **For connection pooling**: Use M3U Profiles when you have multiple logins for the same provider and want Dispatcharr to use them as a combined pool of connections.
 
+            *Related: [#710](https://github.com/Dispatcharr/Dispatcharr/issues/710)*
+
 	* <i data-lucide="square-minus" style="color: red; width: 18px;"></i> delete icon to remove the associated M3U account
 	* <i data-lucide="refresh-cw" style="color: RoyalBlue; width: 18px;"></i> refresh icon to manually refresh/update the associated M3U account
 	

--- a/docs/en/user-guide.md
+++ b/docs/en/user-guide.md
@@ -158,7 +158,14 @@ From this page you can add and maintain your M3U accounts and EPGs
 			    | Example URL | Search Pattern | Replace Pattern |
 				| --- | --- | --- |
 				| `http://provider.com/live/username1/password1/stream` | `username1/password1` | `username2/password2` |
-			
+
+        !!! warning "M3U Profiles are NOT for stream failover"
+            M3U Profiles are designed for managing **multiple accounts from the same provider** to increase your total connection limit. They are NOT used for automatic failover between streams.
+
+            **For stream failover**: Add multiple streams to a single channel. Dispatcharr will automatically switch to the next stream if the current one fails. See [Fallback Streams](/Dispatcharr-Docs/user-guide/#fallback-streams) for details.
+
+            **For connection pooling**: Use M3U Profiles when you have multiple logins for the same provider and want Dispatcharr to use them as a combined pool of connections.
+
 	* <i data-lucide="square-minus" style="color: red; width: 18px;"></i> delete icon to remove the associated M3U account
 	* <i data-lucide="refresh-cw" style="color: RoyalBlue; width: 18px;"></i> refresh icon to manually refresh/update the associated M3U account
 	


### PR DESCRIPTION
## Summary

This PR adds documentation to address common questions and issues identified during a triage of GitHub issues. Each commit addresses a specific issue and includes a link back to the source issue for additional context.

## New Troubleshooting Sections

| Section | Issue | Description |
|---------|-------|-------------|
| Jellyfin EPG not importing | [#583](https://github.com/Dispatcharr/Dispatcharr/issues/583) | TVG-ID format requirements and `?tvg_id_source=tvg_id` parameter |
| Adding multiple Dispatcharr instances to Plex | [#734](https://github.com/Dispatcharr/Dispatcharr/issues/734) | Channel Profiles workaround for device ID conflicts |
| Xtream Codes apps not working through reverse proxy | [#839](https://github.com/Dispatcharr/Dispatcharr/issues/839) | Nginx config for `/live/` endpoint |
| EPG shows wrong data or is "off-by-one" | [#563](https://github.com/Dispatcharr/Dispatcharr/issues/563) | Overlapping channel numbers with Auto Channel Sync |

## Clarifications Added

| Location | Issue | Description |
|----------|-------|-------------|
| M3U Profiles (user-guide) | [#710](https://github.com/Dispatcharr/Dispatcharr/issues/710) | Profiles are for connection pooling, NOT stream failover |
| Jellyfin categories (troubleshooting) | [#538](https://github.com/Dispatcharr/Dispatcharr/issues/538) | Categories pass through automatically from source EPG |

## Plex Limitations Added (getting-started)

| Limitation | Issue | Description |
|------------|-------|-------------|
| VOD not supported | [#470](https://github.com/Dispatcharr/Dispatcharr/issues/470) | Plex cannot display VOD from Dispatcharr |
| Single EPG source | [#633](https://github.com/Dispatcharr/Dispatcharr/issues/633) | Cannot mix zipcode OTA guide with XMLTV |
| Tunarr conflict | [#344](https://github.com/Dispatcharr/Dispatcharr/issues/344) | Must disable Tunarr auto-update to prevent channel mismatch |

## Files Changed

- `docs/en/troubleshooting.md` - 4 new sections, 1 note added
- `docs/en/getting-started.md` - Jellyfin tip + 3 Plex warnings added
- `docs/en/user-guide.md` - M3U Profiles clarification added

## Issues That Can Be Closed After Merge

These open issues can be commented with a link to the relevant docs and closed:

- [#583](https://github.com/Dispatcharr/Dispatcharr/issues/583) - Jellyfin EPG import
- [#710](https://github.com/Dispatcharr/Dispatcharr/issues/710) - Profile Loop (misconception)
- [#839](https://github.com/Dispatcharr/Dispatcharr/issues/839) - XC reverse proxy

---

🤖 Generated with [Claude Code](https://claude.ai/code)