### PR TITLE
Updates for v0.26.0

### DIFF
--- a/docs/en/channels.md
+++ b/docs/en/channels.md
@@ -22,15 +22,16 @@ From the channels page you can create and manage all added channels, streams, an
 * Search by channel group by clicking in the "Group" column header
 * Edit a channel by clicking the corresponding <i data-lucide="square-pen" style="color: gold; width: 18px;"></i> "Edit Channel" icon under the "Actions" column 
     * Channel Name - Edit the name for your Channel
+    * Channel # - Edit the channel number
     * Channel Group - Edit the group for your channel. If you want to create and add to a new group, click the <i data-lucide="square-plus" style="color: LimeGreen; width: 18px;"></i> icon
-    * Stream Profile - Click here if you want to use something other than the default stream profile for this channel
-    * User Level Access - Set which user types can access this channel via Xtream Codes output
     * Logo - Choose a logo, upload a new one, or use logo from the assigned EPG
-    * Mature Content - Toggle whether to set a channel as mature content. Mature content can be hidden from non-admin users via "Hide Mature Content" toggle in [user settings](/Dispatcharr-Docs/system/#users)
-    * Channel # - Edit the channel number. Currently only integers are accepted
     * TVG-ID - Edit the TVG-ID field for your channel. Auto-match tries to match episode guide to this field
     * Gracenote StationID - Edit the Gracenote ID for your channel. These are typically 5 or 6 digit numbers that Gracenote (a common EPG provider) can use to identify TV channels.
     * EPG - Click in the box to manually choose an EPG entry, click "Use Dummy" to assign a dummy EPG entry, or click "Auto Match" to attempt EPG auto-match
+    * Stream Profile - Click here if you want to use something other than the default stream profile for this channel
+    * User Level Access - Set which user types can access this channel via Xtream Codes output
+    * Mature Content - Toggle whether to set a channel as mature content. Mature content can be hidden from non-admin users via "Hide Mature Content" toggle in [user settings](/Dispatcharr-Docs/system/#users)
+    * Hidden - Toggle whether to exclude a channel from all output (HDHR, M3U, EPG, XC) without deleting it
 * Delete a channel by clicking the corresponding <i data-lucide="square-minus" style="color: red; width: 18px;"></i> "Delete channel" icon under the "Actions" column 
 * Preview (play) a channel by clicking the corresponding <i data-lucide="circle-play" style="color: Limegreen; width: 18px;"></i> "Preview channel" icon under the "Actions" column 
 * Toggle the channel check boxes to use the bulk editing buttons above the grid on the selected channels, or to add streams to channels

--- a/docs/en/m3u-epg-manager.md
+++ b/docs/en/m3u-epg-manager.md
@@ -90,7 +90,6 @@ From this page you can add and maintain your M3U accounts and EPGs
         * Name - A name for your EPG
         * URL - The URL for your EPG (may be xml or compressed xml as .gz or .zip)
         * Source Type - Choose XMLTV or Schedules Direct depending on your EPG provider format
-        * API Key - API key for services that require authentication
         * Refresh Interval (hours) - How often (in number of hours) to refresh the EPG
             * Use cron schedule: Click to switch over to `Cron Expression` option
         * Cron Expression: Enter a cron expression to define the EPG account refresh interval, or click `Open Cron Builder` for user-friendly assistance


### PR DESCRIPTION
Reorder and clarify channel edit fields in docs/en/channels.md: add Channel # entry, move Stream Profile, User Level Access and Mature Content entries, and add a new Hidden toggle to exclude channels from outputs without deleting them. In docs/en/m3u-epg-manager.md remove the "API Key" line from EPG account settings to reflect that API key has been removed from the UI.